### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # holaspirit-mcp-server
+[![smithery badge](https://smithery.ai/badge/holaspirit-mcp-server)](https://smithery.ai/server/holaspirit-mcp-server)
 
 A [MCP(Model Context Protocol)](https://www.anthropic.com/news/model-context-protocol) server that accesses to [Holaspirit API](https://www.holaspirit.com/).
 
@@ -23,6 +24,15 @@ Available tools:
 
 ### Installation
 
+#### Installing via Smithery
+
+To install holaspirit-mcp-server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/holaspirit-mcp-server):
+
+```bash
+npx -y @smithery/cli install holaspirit-mcp-server --client claude
+```
+
+#### Installing Manually
 ```bash
 npm install holaspirit-mcp-server
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install holaspirit-mcp-server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/holaspirit-mcp-server

Let me know if any tweaks have to be made!